### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anyio==3.7.0
 blis==1.3.0
-catalogue==2.0.8
+catalogue==2.0.10
 certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,37 @@
 anyio==3.7.0
-blis==0.7.9
+blis==1.3.0
 catalogue==2.0.8
 certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
-confection==0.0.4
+confection==0.1.5
 cymem==2.0.7
-de-core-news-sm @ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.5.0/de_core_news_sm-3.5.0-py3-none-any.whl
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl
-fastapi==0.95.2
+de-core-news-sm @ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.8.0/de_core_news_sm-3.8.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+fastapi==0.115.12
 h11==0.14.0
 idna==3.4
 Jinja2==3.1.2
 langcodes==3.3.0
 MarkupSafe==2.1.2
 murmurhash==1.0.9
-numpy==1.24.3
+numpy==2.2.5
 packaging==23.1
 pathy==0.10.1
 preshed==3.0.8
-pydantic==1.10.8
+pydantic==2.11.3
 requests==2.31.0
 smart-open==6.3.0
 sniffio==1.3.0
-spacy==3.5.3
+spacy==3.8.3
 spacy-legacy==3.0.12
 spacy-loggers==1.0.4
-srsly==2.4.6
-starlette==0.27.0
-thinc==8.1.10
+srsly==2.5.1
+starlette==0.46.2
+thinc==8.3.6
 tqdm==4.65.0
 typer==0.7.0
-typing_extensions==4.6.2
+typing_extensions==4.13.2
 urllib3==2.0.2
 uvicorn==0.22.0
 wasabi==1.1.1


### PR DESCRIPTION
I bumped the package versions in requirements.txt so that `pip install` runs successfully. However now the tests fail with an `AttributeError: 'EntryPoints' object has no attribute 'get'` and starting the service throws the same exception. 


see #8